### PR TITLE
docs(readme): add Nix/NixOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ pacman -S codesnap
 </details>
 
 <details>
+<summary>Nix/NixOS</summary>
+
+CodeSnap is available in the [nixpkgs](https://github.com/NixOS/nixpkgs):
+
+```bash
+nix-env -i codesnap
+```
+
+</details>
+
+<details>
 <summary>Cargo</summary>
 
 ```bash


### PR DESCRIPTION
CodeSnap is now available in the [nixpkgs](https://search.nixos.org/packages?channel=unstable&show=codesnap&from=0&size=50&sort=relevance&type=packages&query=codesnap) repository.