### PR TITLE
[Fix::syntax] avoid filesystem access when guessing syntax

### DIFF
--- a/core/src/utils/syntax_provider.rs
+++ b/core/src/utils/syntax_provider.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "auto-detect")]
 use hyperpolyglot_fork::detectors::classify;
+use std::path::Path;
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 
 use crate::components::interface::render_error::RenderError;
@@ -17,13 +18,20 @@ impl SyntaxProvider {
     ) -> Result<SyntaxReference, RenderError> {
         let syntax = match &language {
             Some(language) => self.syntax_set.find_syntax_by_token(&language),
-            None => match &code_file_path {
-                Some(file_path) => self
-                    .syntax_set
-                    .find_syntax_for_file(&file_path)
-                    .map_err(|_| RenderError::NoSuchFile(file_path.clone()))?,
-                None => self.syntax_set.find_syntax_by_first_line(code),
-            },
+            None => {
+                let by_path = code_file_path.as_deref().and_then(|p| {
+                    let path = Path::new(p);
+                    path.file_name()
+                        .and_then(|n| n.to_str())
+                        .and_then(|n| self.syntax_set.find_syntax_by_extension(n))
+                        .or_else(|| {
+                            path.extension()
+                                .and_then(|e| e.to_str())
+                                .and_then(|e| self.syntax_set.find_syntax_by_extension(e))
+                        })
+                });
+                by_path.or_else(|| self.syntax_set.find_syntax_by_first_line(code))
+            }
         };
 
         #[cfg(feature = "auto-detect")]


### PR DESCRIPTION
**Problem:**
When snapshotting code from a path that syntect can't open, e.g. logical/display path, it fails on file lookup of extensions syntect doesn't know: RenderError::NoSuchFile

_Encountered when snapping something.astro w codesnap.nvim -> codesnap.nvim passes display path (project/something.astro) ->  dylib File::open resolves w cwd to /User/marlene/project/**project/something.astro**_ :(

**Fix:**
find_syntax_by_extension(file_name) - to match find_syntax_for_file()
find_syntax_by_extension(extension)
find_syntax_by_first_line(code) - instead of reading from disk

**Also fixes:** multi-language files like .astro when snapping a slice not in opening section (e.g. HTML in .astro): now lets first-line guessing match the slice itself - previously incorrect based on first line

thx